### PR TITLE
Recent .env.EXAMPLE change introduced a syntax issue.

### DIFF
--- a/Develop/.env.EXAMPLE
+++ b/Develop/.env.EXAMPLE
@@ -1,4 +1,4 @@
-process.env.DB_NAME='ecommerce_db'
-process.env.DB_USER=''
-process.env.DB_PW=''
+DB_NAME='ecommerce_db'
+DB_USER=''
+DB_PW=''
 


### PR DESCRIPTION
Found an issue with the .env.EXAMPLE file setup. This change is unrelated to version and could benefit from being merged right away. The same issue is not present in the class content repo.